### PR TITLE
EASYYY

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   eslint: {
     // Warning: This allows production builds to successfully complete even if
     // your project has ESLint errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@types/node": "^20.19.9",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/react-virtualized": "^9.22.2",
         "autoprefixer": "^10.4.21",
         "eslint": "^9",
         "eslint-config-next": "15.4.5",
@@ -401,6 +402,8 @@
     },
     "node_modules/@humeai/voice-react": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@humeai/voice-react/-/voice-react-0.2.2.tgz",
+      "integrity": "sha512-AyCYV1ZE8iskio7lDjQQdHsETvoVf0OqujG87E/dY7GyzqZtyeo/+zZQnpPYDA/I3cuiouwusMDfZGK5sx2znQ==",
       "license": "ISC",
       "dependencies": {
         "date-fns": "^3.6.0",
@@ -2391,6 +2394,13 @@
       "version": "2019.3.0",
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "dev": true,
@@ -2415,6 +2425,17 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-virtualized": {
+      "version": "9.22.2",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.22.2.tgz",
+      "integrity": "sha512-0Eg/ME3OHYWGxs+/n4VelfYrhXssireZaa1Uqj5SEkTpSaBu5ctFGOCVxcOqpGXRiEdrk/7uho9tlZaryCIjHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/react": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -5338,6 +5359,39 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/framer-motion/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "license": "MIT",
@@ -5884,6 +5938,8 @@
     },
     "node_modules/hume": {
       "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/hume/-/hume-0.12.1.tgz",
+      "integrity": "sha512-6/u3lUVMIr/1BmzI2HLq+BoVW1bTR1m+5TOrxqfSPrMAfCXIHkZo+OHArZEA/gCqox02fvwDnmgXxTvPhRfnGg==",
       "dependencies": {
         "form-data": "^4.0.0",
         "form-data-encoder": "^4.0.2",
@@ -6901,6 +6957,53 @@
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+      "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.12",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
+    },
+    "node_modules/motion/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8016,6 +8119,8 @@
     },
     "node_modules/react-virtualized": {
       "version": "9.22.6",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.6.tgz",
+      "integrity": "sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
@@ -8032,6 +8137,8 @@
     },
     "node_modules/react-virtualized-auto-sizer": {
       "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/node": "^20.19.9",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/react-virtualized": "^9.22.2",
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.4.5",

--- a/src/app/check-in/page.tsx
+++ b/src/app/check-in/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Chat from "@/components/aura/Chat";
+
+export default function Page() {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchToken() {
+      try {
+        const response = await fetch('/api/hume/token');
+        if (!response.ok) {
+          throw new Error('Failed to fetch access token');
+        }
+        const data = await response.json();
+        if (!data.accessToken) {
+          throw new Error('No access token received');
+        }
+        setAccessToken(data.accessToken);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to get access token');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchToken();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="grow flex flex-col items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-4"></div>
+          <p>Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="grow flex flex-col items-center justify-center">
+        <div className="text-center text-red-600">
+          <p className="font-semibold">Error</p>
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!accessToken) {
+    return (
+      <div className="grow flex flex-col items-center justify-center">
+        <div className="text-center text-red-600">
+          <p>Unable to get access token</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <div className="grow flex flex-col">
+      <Chat accessToken={accessToken} />
+      </div>
+    </div>
+    
+  );
+}

--- a/src/components/aura/Chat.tsx
+++ b/src/components/aura/Chat.tsx
@@ -3,20 +3,25 @@
 import { VoiceProvider } from "@humeai/voice-react";
 import Messages from "./Messages";
 import Controls from "./Controls";
+import StartCall from "./StartCall";
 import { ComponentRef, useRef } from "react";
 import { toast } from "sonner";
-import StartCall from "./StartCall";
 
-export default function ClientComponent({ accessToken }: { accessToken: string }) {
+export default function ClientComponent({
+  accessToken,
+}: {
+  accessToken: string;
+}) {
   const timeout = useRef<number | null>(null);
   const ref = useRef<ComponentRef<typeof Messages> | null>(null);
 
   // optional: use configId from environment variable
+  const configId = process.env['NEXT_PUBLIC_HUME_CONFIG_ID'];
   
   return (
     <div
       className={
-        "relative grow flex flex-col mx-auto w-full overflow-hidden h-[0px]"
+        "relative grow flex flex-col mx-auto w-full h-[0px]"
       }
     >
       <VoiceProvider
@@ -42,7 +47,7 @@ export default function ClientComponent({ accessToken }: { accessToken: string }
       >
         <Messages ref={ref} />
         <Controls />
-        <StartCall accessToken={accessToken} />
+        <StartCall configId={configId} accessToken={accessToken} />
       </VoiceProvider>
     </div>
   );

--- a/src/components/aura/MicFFT.tsx
+++ b/src/components/aura/MicFFT.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/utils";
 import { motion } from "motion/react";
-import AutoSizer from "react-virtualized-auto-sizer"
+import { AutoSizer } from "react-virtualized";
 
 export default function MicFFT({
   fft,

--- a/src/contexts/HumeContext.tsx
+++ b/src/contexts/HumeContext.tsx
@@ -28,7 +28,7 @@ function Hume({ children }: HumeProps) {
   });
 
   useEffect(() => {
-    const fetchApiKey = async () => {
+    const fetchApiKeyInner = async () => {
       try {
         console.log("Fetching Hume API key from server...");
         
@@ -60,7 +60,7 @@ function Hume({ children }: HumeProps) {
       }
     };
 
-    fetchApiKey();
+    fetchApiKeyInner();
   }, []);
 
   return <HumeContext.Provider value={hume}>{children}</HumeContext.Provider>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce client-side check-in page to fetch Hume tokens and render the Chat component, pass optional Hume configuration ID to the StartCall component, and align project configuration and dependencies.

New Features:
- Add client-side `/check-in` page that fetches Hume access tokens, handles loading and error states, and renders the Chat component

Enhancements:
- Pass optional `configId` from `NEXT_PUBLIC_HUME_CONFIG_ID` into the `StartCall` component
- Replace `react-virtualized-auto-sizer` with `AutoSizer` from `react-virtualized` and add its type definitions
- Rename `next.config.ts` to `next.config.js` with JSDoc type annotation

Build:
- Update `tsconfig.json` to include `next.config.ts`

Chores:
- Rename Hume context API key fetch function to avoid naming collision